### PR TITLE
parrallelize and add additional preprocessing opts

### DIFF
--- a/src/multicore_processor.py
+++ b/src/multicore_processor.py
@@ -1,0 +1,76 @@
+"""A script to process the textual data, and format
+it into a pandas dataframe which is then pickeled (A
+way of storing objects in python.
+
+The arguments should be given by command line and in the order
+<file location> <save location>.  If no arguments are provided, the
+script will attempt to read the input file ../data/training_text.csv and save
+it to ../data/training_df.pk
+
+Ex usage
+$python text_processor ../data/training_text.csv ../data/text_new.pk
+
+ processing data
+ 2496 lines processed
+$
+"""
+import preprocessing as prep
+import pandas as pd
+import sys
+from multiprocessing import Process, Pool, TimeoutError
+
+help_string="""
+A script to process the textual data, and format
+it into a pandas dataframe which is then pickeled (A
+way of storing objects in python.
+
+The arguments should be given by command line and in the order
+<save location> <mode>. 
+The valid options for mode are 
+  - tokenize
+  - stem
+  - genes 
+
+Ex usage
+$python text_processor genes
+
+ processing data
+ 2496 lines processed
+$
+"""
+def clean_and_tokenize(x):
+    return prep.port_tokenizer(prep.clean_text(x), var, genes)
+
+if __name__=="__main__":
+    save_location="../data/training_df.pk"
+    training_text_loc="../data/training_text.csv"
+    test_text_loc = '../data/test_text.csv'
+    test_loc = "../data/test_variants.csv"
+    train_loc = "../data/training_variants.csv"
+    var, genes = prep.get_genes_variants(train_loc, test_loc)
+    
+    if len(sys.argv)==2:
+        if sys.argv[1] in {'help','h','-h','--help'}:
+            print(help_string)
+            sys.exit()
+        elif sys.argv[1] not in {'tokenize', 'stem', 'genes'}:
+            print('unknown method, valid methods are tokenize, stem, or gene')
+            sys.exit()
+        method=sys.argv[1]
+    else:
+        print("unknown option, enter help as command line option for help")
+    for train_test in ['train','test']:
+        print('loading dataframe')
+        file_location = training_text_loc if train_test=='train'\
+                else test_text_loc
+        df = pd.read_csv(file_location, delimiter=r'\|\|', index_col=0,
+                         encoding='utf-8', engine='python', skiprows=1,
+                         names=['text'])
+        print('processing data')
+
+        pool = Pool()
+        processor = prep.processor(var, genes, method=method)
+        df['processed'] = pool.map(processor.process_text, df.text)
+        df.to_pickle(''.join(['../data/',method,'-',train_test,'.pk']))
+        print('saved file, {} lines processed'.format(df.size))
+

--- a/src/preprocessing.py
+++ b/src/preprocessing.py
@@ -3,9 +3,10 @@ used with the kaggle cancer text data
 """
 import re
 import nltk
+import pandas as pd
+stopwords = set(nltk.corpus.stopwords.words('english'))
 
-
-def port_tokenizer(text):
+def port_tokenizer(text, variants, genes):
     """Splits and tokenizes text.   The split is done on
     any pattern that isn't a letter, number, or dash thats longer
     1 or more characters long.
@@ -13,20 +14,115 @@ def port_tokenizer(text):
     Parameters:
     ---------------
     text: str, string to tokenize
+    variants, set(str)
+        Set of all names of variants in test and training set
+    genes, set(str)
+        Set of all names of genes in the test and trianing set
+
 
     Returns:
     ---------------
     list of tokens (strings) formed by splitting the original text
+    and removing stopwords (note genes/variants are left uppercase)
     """
-    words = re.split(r'[^a-z0-9-]+', text.lower())
+    words = re.split(r'[^a-zA-Z0-9-*]+', text)
     ps = nltk.stem.porter.PorterStemmer()
-    return [ps.stem(word) for word in words if word not in
-            nltk.corpus.stopwords.words('english') and word]
+
+    return [ps.stem(process_word(word, variants, genes)) for word in words if process_word(word, variants, genes)]
+
+def tokenizer(text, variants, genes):
+    """Splits and tokenizes text.   The split is done on
+    any pattern that isn't a letter, number, or dash thats longer
+    1 or more characters long.
+
+    Parameters:
+    ---------------
+    text: str, string to tokenize
+    variants, set(str)
+        Set of all names of variants in test and training set
+    genes, set(str)
+        Set of all names of genes in the test and trianing set
+
+
+    Returns:
+    ---------------
+    list of tokens (strings) formed by splitting the original text
+    and removing stopwords (note genes/variants are left uppercase)
+    """
+    words = re.split(r'[^a-zA-Z0-9-*]+', text)
+    return [process_word(word, variants, genes) for word in words if process_word(word, variants, genes)]
+
+
+def gene_tokenizer(text, variants, genes):
+    """splits a text, and then only returns the words which contain genes
+    """
+    words = re.split(r'[^a-zA-Z0-9*]', text)
+    var_genes = variants.union(genes)
+    return [word for word in words if word in var_genes]
+
+
+def process_word(word, variants, genes):
+    """ Returns a word if the word is long enough to be
+        a word, is not a number, and is not found in 
+        var or genes
+
+    Parameters:
+    ----------
+    word: str
+        word to be processed
+    var: set(str)
+        set of gene variations
+    genes: set(str)
+        set of genes
+    
+    Returns:
+    --------
+    a string corresponding to processed word or ''
+    """
+    numbers = {'one', 'two', 'three', 'four', 'five', 'six',
+               'seven', 'eight', 'nine', 'ten', 'elevin', 'twelve',
+               'hundred', 'thousand', 'million'}
+    if word in variants or word in genes:
+        return word
+    if word in numbers:
+        return ''
+    if len(word) <= 2:
+        return ''
+    if word not in stopwords:
+        return word.lower()
+    return ''
+
+
+def get_genes_variants(train_loc, test_loc):
+    """
+    finds the genes and the varients from
+    the data and stores them in a two sets.
+
+    Parameters:
+    -----------
+    train_loc: str
+        filename of training data
+    test_loc: str
+        filename of test data
+
+    Returns:
+    --------
+    Varients:
+        set of all possible variations
+    genes:
+        set of all possible genes
+    """
+    df_train = pd.read_csv(train_loc, index_col=0)
+    df_test = pd.read_csv(test_loc, index_col=0)
+    genes = set(df_train.Gene.unique()).union(set(df_test.Gene.unique()))
+    variants = set(df_train.Variation.unique())\
+        .union(set(df_test.Variation.unique()))
+    return genes, variants
 
 
 def clean_text(text):
     """Removes references, figure references and numbers from text
-    and returns the lowercase string
+    and returns the cleaned string
 
     example:
     >>>process_text("As we can see from fig. 1 and the results from [1]")
@@ -55,14 +151,33 @@ def clean_text(text):
     # remove letter refernces, ie "[A]"
     text = re.sub(r'[([][a-zA-Z][)\]]', '', text)
     # remove numbers
-    text = re.sub(r'\s([0-9,.%]+)\s', '', text)
-    return text.lower().strip()
+    text = re.sub(r'[^a-zA-Z0-9-]([0-9,.%]+)\s', '', text)
+    # get rid of apostrophes and quoutes
+    text = re.sub("'", '', text)
+    text = re.sub('"', '', text)
+    return text.strip()
 
 
-def process_text(text):
+
+def process_text(text, variants={}, genes={}):
     """Removes references, figure references and numbers from text
     Then tokenizes the text by splitting it up on anything that isn't a letter,
     a number, or a dash, and returns the list, with stopwords removed
     """
     test = clean_text(text)
-    return port_tokenizer(text)
+    return port_tokenizer(text, variants, genes)
+
+class processor(object):
+    def __init__(self, variants, genes, method='stem'):
+        self.variants = variants
+        self.genes = genes
+        self.method=method
+    def process_text(self,text):
+        if self.method == 'stem':
+            return process_text(text,self.variants,self.genes)
+        elif self.method == 'tokenize':
+            return tokenizer(text, self.variants, self.genes)
+        elif self.method == 'genes':
+            return gene_tokenizer(text, self.variants, self.genes)
+            
+    

--- a/test/unittests.py
+++ b/test/unittests.py
@@ -5,7 +5,6 @@ run `make test`
 '''
 from __future__ import division
 import unittest as unittest
-import numpy as np
 from src import preprocessing
 
 
@@ -13,24 +12,35 @@ class TestPreprocessing(unittest.TestCase):
 
     def test_remove_fig(self):
         result = preprocessing.clean_text("From fig. 1 we see")
-        self.assertEqual(result,"from  we see")
+        self.assertEqual(result, "From  we see")
 
     def test_remove_figure(self):
         result = preprocessing.clean_text("see Figure A")
-        self.assertEqual(result,"see")
+        self.assertEqual(result, "see")
 
     def test_remove_number(self):
         result = preprocessing.clean_text("the result increased by 22.7%")
-        self.assertEqual(result,"the result increased by")
+        self.assertEqual(result, "the result increased by")
 
     def test_remove_number_comma(self):
         result = preprocessing.clean_text("the numbers range from 1,2,3")
-        self.assertEqual(result,"the numbers range from")
+        self.assertEqual(result, "the numbers range from")
 
     def test_dont_remove_gene(self):
         result = preprocessing.clean_text("the gene WK320 is associated with")
-        self.assertEqual(result,"the gene wk320 is associated with")
+        self.assertEqual(result, "the gene WK320 is associated with")
 
     def test_remove_letter_reference(self):
         result = preprocessing.clean_text("from [a] we see that [B] should")
-        self.assertEqual(result,"from  we see that  should")
+        self.assertEqual(result, "from  we see that  should")
+
+    def test_process_words(self):
+        genes, variations = preprocessing.get_genes_variants(
+                            'data/training_variants.csv',
+                             'data/test_variants.csv')
+        self.assertIn('CIC', genes)
+        self.assertIn('DHCR7', genes)
+        self.assertIn('W802*', variations)
+        self.assertIn('L399V', variations)
+        
+


### PR DESCRIPTION
  - Make preprocessing parrallel in multicore_processor.py
  - Add gene option to preprocessing which only keeps genes
    and variations
  - Add tokenize option to preprocessing which only tokenizes
    and removes stopwords, but does not stem.